### PR TITLE
Update pcs_resource.py

### DIFF
--- a/library/pcs_resource.py
+++ b/library/pcs_resource.py
@@ -174,7 +174,7 @@ def main():
                 if rc == 0:
                     module.exit_json(changed=True)
                 else:
-                    module.fail_json(msg="Failed to create resource: " + out)
+                    module.fail_json(msg="Failed to create resource: " + out + err)
 
         elif state == 'present' and resource is not None:
             # resource should be present and we have find resource with such ID - lets compare it with definition if it needs a change


### PR DESCRIPTION
In case resource fails to be added, display stderr in the module output.
It helps to find out why the command failed.

Ansible output before:
`"msg": "Failed to create resource: "`

Ansible output after (example):
`"msg": "Failed to create resource: Error: required resource option 'clientspec' is missing, use --force to override\n"`