### PR TITLE
Pcs resource wait

### DIFF
--- a/library/pcs_resource.py
+++ b/library/pcs_resource.py
@@ -89,6 +89,12 @@ EXAMPLES = '''
     name: 'test'
     resource_type: 'ocf:pacemaker:Dummy'
 
+- name: ensure Dummy('ocf:pacemaker:Dummy') resource with name 'test' is present and wait for it to be started
+  pcs_resource:
+    name: 'test'
+    resource_type: 'ocf:pacemaker:Dummy'
+    wait: true
+
 - name: create 'stonith' class resource 'kdump' of type 'fence_kdump'
   pcs_resource:
     name: 'kdump'

--- a/library/pcs_resource.py
+++ b/library/pcs_resource.py
@@ -47,7 +47,7 @@ options:
     description:
       - "additional options passed to 'pcs' command"
     required: false
-  wait:
+  wait_on_create:
     description:
       - "use '--wait' when creating the resource"
     default: no
@@ -89,11 +89,11 @@ EXAMPLES = '''
     name: 'test'
     resource_type: 'ocf:pacemaker:Dummy'
 
-- name: ensure Dummy('ocf:pacemaker:Dummy') resource with name 'test' is present and wait for it to be started
+- name: ensure Dummy('ocf:pacemaker:Dummy') resource with name 'test' is present and wait for it to be up if created
   pcs_resource:
     name: 'test'
     resource_type: 'ocf:pacemaker:Dummy'
-    wait: true
+    wait_on_create: true
 
 - name: create 'stonith' class resource 'kdump' of type 'fence_kdump'
   pcs_resource:
@@ -269,7 +269,7 @@ def run_module():
             resource_class=dict(default="ocf", choices=['ocf', 'systemd', 'stonith', 'master', 'promotable']),
             resource_type=dict(required=False),
             options=dict(default="", required=False),
-            wait=dict(default=False, type='bool', required=False),
+            wait_on_create=dict(default=False, type='bool', required=False),
             force_resource_update=dict(default=False, type='bool', required=False),
             cib_file=dict(required=False),
             child_name=dict(required=False),
@@ -289,7 +289,7 @@ def run_module():
     ignored_meta_attributes = module.params['ignored_meta_attributes']
 
     # check if --wait shall be used when creating a resource
-    if module.params['wait']:
+    if module.params['wait_on_create']:
         module.params['token_wait'] = '--wait'
     else:
         module.params['token_wait'] = ''


### PR DESCRIPTION
hi again,

here is a small hack that we use to wait for resources. i am not sure if it is a good generic way to do it like this, so if you dislike it, no problem. At least this time `--wait` is supported by 0.9 and 0.10.

I also read #28, so maybe `pcs_wait_for` would be a better solution, but it seems it is not here yet.

Rationale: We had problems that resources will take some time to get up and running after getting created and the next tasks in playbook/role then would fail.

First we tried to use `--wait` at the end of options string. That works fine when creating a service but it fails when the service is already here, e.g.:
```
TASK [el8cs-cluster : DLM resource] ********************************************************************************
fatal: [inf155]: FAILED! => {"changed": false, "error": "Error: Cannot use '-f' together with '--wait'\n", "msg": "Unable to simulate resource with given definition using command 'pcs -f /tmp/tmpnb77vb8b resource create dlm ocf:pacemaker:controld args=\"--protocol=sctp\" op monitor interval=30s on-fail=fence --group locking --wait'", "output": ""}
```

So what this pull request does is passes `--wait` only when creating the resource. Thus i called the option `wait_on_create`. Besides that we noticed, that if we add the `--wait` to the next run_command (the comment says it is only used in el6) it would fail, too. So it seems that in CentOS 8.1 this second cal is triggered and it is important to have no `--wait` there. We had no time to debug this yet.

To sum it up: I just wanted to show you what we did, if you think it is not useful for everyone, just reject this pull request. We will happily use `pcs_wait_for` once it is available.