### PR TITLE
Fix token option for pcs v0.10

### DIFF
--- a/library/pcs_cluster.py
+++ b/library/pcs_cluster.py
@@ -234,7 +234,7 @@ def run_module():
         elif pcs_version == '0.10':
             if ((module.params['transport_options'] != '') and (module.params['transport'] == 'default')):
                 module.fail_json(msg="using option transport_option must not be used without option transport")
-            module.params['token_param'] = '' if (not module.params['token']) else 'token %(token)s' % module.params
+            module.params['token_param'] = '' if (not module.params['token']) else 'totem token=%(token)s' % module.params
             module.params['transport_param'] = '' if (module.params['transport'] == 'default') else 'transport %(transport)s' % module.params
             if ',' in module.params['node_list']:
                 # rewrite node_list to conform to pcs-0.10 format with multiple links


### PR DESCRIPTION
The token option did not work for pcs v0.10.10

Syntax is:

```
Usage: pcs cluster setup...
    setup <cluster name> (<node name> [addr=<node address>]...)...
            [transport knet|udp|udpu
                [<transport options>] [link <link options>]...
                [compression <compression options>] [crypto <crypto options>]
            ] [totem <totem options>] [quorum <quorum options>]
            ([--enable] [--start [--wait[=<n>]]] [--no-keys-sync])
            | [--corosync_conf <path>]
```

Tested with pcs version 0.10.10 on AlmaLinux 8.5.