### PR TITLE
Pacemaker 2.1.0 deprecated Master and Slave role names in favor of Promoted and Unpromoted

### DIFF
--- a/library/pcs_constraint_colocation.py
+++ b/library/pcs_constraint_colocation.py
@@ -43,14 +43,14 @@ options:
     description:
       - Role of resource1
     required: false
-    choices: ['Master', 'Slave', 'Started']
+    choices: ['Master', 'Slave', 'Promoted', 'Unpromoted', 'Started']
     default: 'Started'
     type: str
   resource2_role:
     description:
       - Role of resource2
     required: false
-    choices: ['Master', 'Slave', 'Started']
+    choices: ['Master', 'Slave', 'Promoted', 'Unpromoted', 'Started']
     default: 'Started'
     type: str
   score:
@@ -116,8 +116,8 @@ def run_module():
             state=dict(default="present", choices=['present', 'absent']),
             resource1=dict(required=True),
             resource2=dict(required=True),
-            resource1_role=dict(required=False, choices=['Master', 'Slave', 'Started'], default='Started'),
-            resource2_role=dict(required=False, choices=['Master', 'Slave', 'Started'], default='Started'),
+            resource1_role=dict(required=False, choices=['Master', 'Slave', 'Promoted', 'Unpromoted', 'Started'], default='Started'),
+            resource2_role=dict(required=False, choices=['Master', 'Slave', 'Promoted', 'Unpromoted', 'Started'], default='Started'),
             score=dict(required=False, default="INFINITY"),
             influence=dict(required=False, type='bool', default=True),
             cib_file=dict(required=False),


### PR DESCRIPTION
Updating the role names is necessary to make the module compatible with [Pacemaker-2.1.0](https://github.com/ClusterLabs/pacemaker/releases/tag/Pacemaker-2.1.0) release and newer, which added the following support:

- _support for OCF Resource Agent API 1.1 standard_
  - _allow Promoted and Unpromoted role names in CIB (in addition to Master and Slave, which are deprecated), and use new role names in output, logs, and constraints created by crm_resource --ban_