### PR TITLE
Add rule support for location constraints

### DIFF
--- a/library/pcs_constraint_location.py
+++ b/library/pcs_constraint_location.py
@@ -101,7 +101,7 @@ EXAMPLES = '''
   pcs_constraint_location:
     resource: 'resA'
     constraint_id: 'resA_ping_check'
-    rule: 'pingd lt 1 or not_defined pingd'
+    rule: 'not_defined pingd or pingd lt 1'
     score: '-INFINITY'
 
 - name: resource resA prefers to run on the current node during working hours

--- a/library/pcs_constraint_location.py
+++ b/library/pcs_constraint_location.py
@@ -139,7 +139,7 @@ class DateSpec:
 
     def __init__(self, expression):
         for match_group in re.findall(
-            r"(hours|monthdays|weekdays|yeardays|months|weeks|years|weekyears|moon)=['\"]?(\S+)['\"]?\s*",
+            r"(hours|monthdays|weekdays|yeardays|months|weeks|years|weekyears|moon)=['\"]?([\w-]+)['\"]?\s*",
             expression,
         ):
             setattr(self, match_group[0], match_group[1])
@@ -197,7 +197,7 @@ class RscLocationRuleExpression:
         # expression: date-spec <duration>
         exp_parsed = re.search(r"^date-spec\s+(.*)$", expression)
         if exp_parsed:
-            self.operation = "date-spec"
+            self.operation = "date_spec"
             self.date_spec = DateSpec(exp_parsed.group(1))
             return
 

--- a/library/pcs_constraint_location.py
+++ b/library/pcs_constraint_location.py
@@ -162,7 +162,7 @@ class DateSpec:
             return False
         return True
 
-    def __repr__(self) -> str:
+    def __repr__(self):
         return (
             "DateSpec(hours:%s, weekdays:%s, monthdays:%s, yeardays:%s, months:%s, weeks:%s, years:%s, weekyears:%s, moon:%s)"
             % (
@@ -256,7 +256,7 @@ class RscLocationRuleExpression:
 
         return True
 
-    def __repr__(self) -> str:
+    def __repr__(self):
         return (
             "RscLocationRuleExpression(operation:%s, attribute:%s, value:%s, start:%s, end:%s, date_spec:%s)"
             % (

--- a/library/pcs_constraint_location.py
+++ b/library/pcs_constraint_location.py
@@ -127,24 +127,24 @@ from distutils.spawn import find_executable
 from ansible.module_utils.basic import AnsibleModule
 
 class DateSpec:
-    hours: str | int = None
-    monthdays: str | int = None
-    weekdays: str | int = None
-    yeardays: str | int = None
-    months: str | int = None
-    weeks: str | int = None
-    years: str | int = None
-    weekyears: str = None
-    moon: str | int = None
+    hours = None
+    monthdays = None
+    weekdays = None
+    yeardays = None
+    months = None
+    weeks = None
+    years = None
+    weekyears = None
+    moon = None
 
-    def __init__(self, expression: str):
+    def __init__(self, expression):
         for match_group in re.findall(
             r"(hours|monthdays|weekdays|yeardays|months|weeks|years|weekyears|moon)=['\"]?(\w+)['\"]?\s*",
             expression,
         ):
             setattr(self, match_group[0], match_group[1])
 
-    def compare(self, xml: ET.Element) -> bool:
+    def compare(self, xml):
         """Check if given XML element matches the date-spec expression."""
         if any(
             [
@@ -163,14 +163,14 @@ class DateSpec:
         return True
 
 class RscLocationRuleExpression:
-    operation: str
-    attribute: str = None
-    value: str = None
-    start: str = None
-    end: str = None
-    date_spec: DateSpec = None
+    operation = None
+    attribute = None
+    value = None
+    start = None
+    end = None
+    date_spec = None
 
-    def __init__(self, expression: str):
+    def __init__(self, expression):
         # expression: date gt|lt <date>
         exp_parsed = re.search(r"^date\s+(gt|lt)\s+(.*)$", expression)
         if exp_parsed:
@@ -216,7 +216,7 @@ class RscLocationRuleExpression:
             self.value = exp_parsed.group(3)
             return
 
-    def compare(self, xml: ET.Element) -> bool:
+    def compare(self, xml):
         """Check if given XML element matches the rule expression."""
         date_spec = xml.find("duration") or xml.find("date_spec")
         if any(
@@ -240,7 +240,7 @@ class RscLocationRuleExpression:
 
         return True
 
-def compare_rule_to_element(rule_string: str, xml_rule: ET.Element) -> bool:
+def compare_rule_to_element(rule_string, xml_rule):
     boolean_op = xml_rule.attrib.get("boolean-op")
     if boolean_op and " %s " % boolean_op not in rule_string:
         return False

--- a/library/pcs_constraint_location.py
+++ b/library/pcs_constraint_location.py
@@ -162,6 +162,22 @@ class DateSpec:
             return False
         return True
 
+    def __repr__(self) -> str:
+        return (
+            "DateSpec(hours:%s, weekdays:%s, monthdays:%s, yeardays:%s, months:%s, weeks:%s, years:%s, weekyears:%s, moon:%s)"
+            % (
+                self.hours,
+                self.weekdays,
+                self.monthdays,
+                self.yeardays,
+                self.months,
+                self.weeks,
+                self.years,
+                self.weekyears,
+                self.moon,
+            )
+        )
+
 class RscLocationRuleExpression:
     operation = None
     attribute = None
@@ -239,6 +255,19 @@ class RscLocationRuleExpression:
             return self.date_spec.compare(date_spec)
 
         return True
+
+    def __repr__(self) -> str:
+        return (
+            "RscLocationRuleExpression(operation:%s, attribute:%s, value:%s, start:%s, end:%s, date_spec:%s)"
+            % (
+                self.operation,
+                self.attribute,
+                self.value,
+                self.start,
+                self.end,
+                self.date_spec,
+            )
+        )
 
 def compare_rule_to_element(rule_string, xml_rule):
     boolean_op = xml_rule.attrib.get("boolean-op")

--- a/library/pcs_constraint_location.py
+++ b/library/pcs_constraint_location.py
@@ -139,7 +139,7 @@ class DateSpec:
 
     def __init__(self, expression):
         for match_group in re.findall(
-            r"(hours|monthdays|weekdays|yeardays|months|weeks|years|weekyears|moon)=['\"]?(\w+)['\"]?\s*",
+            r"(hours|monthdays|weekdays|yeardays|months|weeks|years|weekyears|moon)=['\"]?(\S+)['\"]?\s*",
             expression,
         ):
             setattr(self, match_group[0], match_group[1])

--- a/library/pcs_constraint_location.py
+++ b/library/pcs_constraint_location.py
@@ -251,7 +251,7 @@ class RscLocationRuleExpression:
         if date_spec is None and self.date_spec is None:
             return True
 
-        if date_spec and self.date_spec:
+        if date_spec is not None and self.date_spec is not None:
             return self.date_spec.compare(date_spec)
 
         return True

--- a/library/pcs_constraint_location.py
+++ b/library/pcs_constraint_location.py
@@ -38,7 +38,22 @@ options:
   node_name:
     description:
       - node name for constraints
-    required: true
+      - One of C(rule) or C(node_name) is required
+      - Mutually exclusive with C(rule)
+    required: false
+    type: str
+  rule:
+    description:
+      - rule expression for constraints
+      - One of C(rule) or C(node_name) is required
+      - Mutually exclusive with C(node_name)
+    required: false
+    type: str
+  constraint_id:
+    description:
+      - unique name for the constraint
+      - Required by I(rule)
+    required: false
     type: str
   score:
     description:
@@ -81,6 +96,27 @@ EXAMPLES = '''
     node_name: 'node2'
     score: '-INFINITY'
     state: 'absent'
+
+- name: moving resources due to connectivity changes (needs ocf:pacemaker:ping resource)
+  pcs_constraint_location:
+    resource: 'resA'
+    constraint_id: 'resA_ping_check'
+    rule: 'pingd lt 1 or not_defined pingd'
+    score: '-INFINITY'
+
+- name: resource resA prefers to run on the current node during working hours
+  pcs_constraint_location:
+    resource: 'resA'
+    constraint_id: 'resA_working_hours'
+    rule: 'date-spec hours="9-16" weekdays="1-5"'
+    score: 'INFINITY'
+
+- name: resource resA prefers to run on the current node since 2022
+  pcs_constraint_location:
+    resource: 'resA'
+    constraint_id: 'resA_since_2022'
+    rule: 'date gt 2022-01-01'
+    score: 'INFINITY'
 '''
 
 import os.path


### PR DESCRIPTION
Hi @OndrejHome 

this is my approach to add rule support for location constraints. In fact there is no generic possibility to fetch a matching constraint rule (_like we do for `prefers` constraints by checking the `node-name`_) I thought we need to add an identifier for rule-based constraints.
it is tested with
```yaml
  tasks:
    - ansible.builtin.import_role:
        name: ondrejhome.pcs-modules-2
    - pcs_constraint_location:
        resource: "RES_Webserver_VIP"
        rule: "pingd lt 1 or not_defined pingd"
        constraint_id: "location-RES_Webserver_VIP-1"
        score: "-INFINITY"
      run_once: true
    - pcs_constraint_location:
        resource: "RES_Webserver_VIP"
        rule: "pingd lt 1"
        constraint_id: "location-RES_Webserver_VIP-2"
        score: "-INFINITY"
      run_once: true
```

- fixes #25

Todo
- [x] add docs and example