### PR TITLE
Cache sys.stdout instead of assuming it is equal to sys.__stdout__

### DIFF
--- a/library/pcs_resource.py
+++ b/library/pcs_resource.py
@@ -179,11 +179,12 @@ def compare_resources(module, res1, res2):
     n1_file = open(n1_tmp_path, 'w')
     n2_file = open(n2_tmp_path, 'w')
     # dump the XML resource definitions into temporary files
+    old_stdout = sys.stdout
     sys.stdout = n1_file
     ET.dump(res1)
     sys.stdout = n2_file
     ET.dump(res2)
-    sys.stdout = sys.__stdout__
+    sys.stdout = old_stdout
     # close files
     n1_file.close()
     n2_file.close()


### PR DESCRIPTION
When running under Mitogen, pcs_resource breaks execution by overwriting sys.stdout with sys.stdout.

With Mitogen, sys.stdout != sys.stdout at this point in the code, and changing it in this manner results in access to closed file descriptors for future invocations. Generally, it is recommended not to use sys.stdout and instead explicitly cache the current value of sys.stdout as proposed in this PR.
