### PR TITLE
Fix pcs_property.py index out of range

### DIFF
--- a/library/pcs_property.py
+++ b/library/pcs_property.py
@@ -4,6 +4,7 @@
 # Apache License v2.0 (see LICENSE-APACHE2.txt or http://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import absolute_import, division, print_function
+from packaging import version
 __metaclass__ = type
 
 
@@ -117,19 +118,17 @@ def run_module():
         module.params['cib_file_param'] = '-f ' + cib_file
 
     # get the pcs major.minor version
-    rc, out, err = module.run_command('pcs --version')
-    if rc == 0:
-        pcs_version = out.split('.')[0] + '.' + out.split('.')[1]
-    else:
+    rc, pcs_version, err = module.run_command('pcs --version')
+    if rc != 0:
         module.fail_json(msg="pcs --version exited with non-zero exit code (" + rc + "): " + out + err)
 
     # get property list from running cluster
     if node is not None:
         rc, out, err = module.run_command('pcs %(cib_file_param)s node attribute' % module.params)
     else:
-        if pcs_version in ['0.9']:
+        if version.parse(pcs_version) >= version.parse("0.9.0") and version.parse(pcs_version) < version.parse("0.10.0"):
             cmd = 'pcs %(cib_file_param)s property show' % module.params
-        elif pcs_version in ['0.10', '0.11', '0.12']:
+        elif version.parse(pcs_version) >= version.parse("0.10.0") and version.parse(pcs_version) < version.parse("0.13.0"):
             cmd = 'pcs %(cib_file_param)s property config' % module.params
         else:
             module.fail_json(msg="unsupported version of pcs (" + pcs_version + "). Only versions 0.9, 0.10, 0.11 and 0.12 are supported.")
@@ -141,6 +140,7 @@ def run_module():
         property_type = None
         properties['cluster'] = {}
         properties['node'] = {}
+        delimiter = '=' if version.parse(pcs_version) > version.parse("0.11.5") else ':'
         # we are stripping last line as they doesn't contain properties
         for row in out.split('\n')[0:-1]:
             # based on row we see the section to either cluster or node properties
@@ -149,11 +149,6 @@ def run_module():
             elif row == 'Node Attributes:':
                 property_type = 'node'
             else:
-                if pcs_version in ['0.9', '0.10']:
-                    delimiter = ':'
-                elif pcs_version in ['0.11', '0.12']:
-                    delimiter = '='
-
                 # when identifier of section is not preset we are at the property
                 tmp = row.lstrip().split(delimiter)
                 if property_type == 'cluster':


### PR DESCRIPTION
There's a bug in pcs_property module on Debian 12 (bookworm)
This task

- name: Disable stonith
  ondrejhome.ha_cluster.pcs_property:
    name: "stonith-enabled"
    value: "false"
    state: present

Produces this error

```
Traceback (most recent call last):
  File \"/home/clusteradm/.ansible/tmp/ansible-tmp-1753098572.2645745-58023-44266858434604/AnsiballZ_pcs_property.py\", line 107, in <module>
    _ansiballz_main()
  File \"/home/clusteradm/.ansible/tmp/ansible-tmp-1753098572.2645745-58023-44266858434604/AnsiballZ_pcs_property.py\", line 99, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File \"/home/clusteradm/.ansible/tmp/ansible-tmp-1753098572.2645745-58023-44266858434604/AnsiballZ_pcs_property.py\", line 47, in invoke_module
    runpy.run_module(mod_name=ansible_collections.ondrejhome.ha_cluster.plugins.modules.pcs_property, init_globals=dict(_module_fqn=ansible_collections.ondrejhome.ha_cluster.plugins.modules.pcs_property, _modlib_path=modlib_path),
  File \"<frozen runpy>\", line 226, in run_module
  File \"<frozen runpy>\", line 98, in _run_module_code
  File \"<frozen runpy>\", line 88, in _run_code
  File \"/tmp/ansible_ondrejhome.ha_cluster.pcs_property_payload_0u9hfc0f/ansible_ondrejhome.ha_cluster.pcs_property_payload.zip/ansible_collections/ondrejhome/ha_cluster/plugins/modules/pcs_property.py\", line 216, in <module>
  File \"/tmp/ansible_ondrejhome.ha_cluster.pcs_property_payload_0u9hfc0f/ansible_ondrejhome.ha_cluster.pcs_property_payload.zip/ansible_collections/ondrejhome/ha_cluster/plugins/modules/pcs_property.py\", line 212, in main
  File \"/tmp/ansible_ondrejhome.ha_cluster.pcs_property_payload_0u9hfc0f/ansible_ondrejhome.ha_cluster.pcs_property_payload.zip/ansible_collections/ondrejhome/ha_cluster/plugins/modules/pcs_property.py\", line 160, in run_module
IndexError: list index out of range
```

pcs version is 11.5

Output of pcs property config

```
Cluster Properties:
 cluster-infrastructure: corosync
 cluster-name: d_artagnan
 dc-version: 2.1.5-a3f44794f94
 have-watchdog: false
```

Delimiter is ":"