### PR TITLE
fix: align pcs version checks with supported 0.9–0.12 range

### DIFF
--- a/library/pcs_auth.py
+++ b/library/pcs_auth.py
@@ -163,7 +163,7 @@ def run_module():
                 else:
                     module.fail_json(msg="Failed to de-authenticate node using command '" + cmd_deauth + "'", output=out, error=err)
             else:
-                module.fail_json(msg="unsupported version of pcs (" + pcs_version + "). Only versions 0.9 and 0.10 are supported.")
+                module.fail_json(msg="unsupported version of pcs (" + pcs_version + "). Only versions 0.9, 0.10, 0.11 and 0.12 are supported.")
 
     else:
         result['changed'] = False

--- a/library/pcs_constraint_colocation.py
+++ b/library/pcs_constraint_colocation.py
@@ -152,7 +152,7 @@ def run_module():
         module.fail_json(msg="pcs --version exited with non-zero exit code (" + rc + "): " + out + err)
 
     # influence support was introduced in 0.11
-    if pcs_version == '0.11':
+    if pcs_version in ['0.11', '0.12']:
         influence = module.params['influence'] = 'influence=true' if module.params['influence'] else 'influence=false'
     elif not module.params['influence']:
         # influence=False (not supported for pcs<0.11)
@@ -250,7 +250,7 @@ def run_module():
 
     elif state == 'present' and constraint is not None:
         # constraint should be present, lets see if it has different score from requested, if yes, then we do update
-        if constraint.attrib.get('score', 'INFINITY') != score or (pcs_version == '0.11' and 'influence=' + constraint.attrib.get('influence', 'true') != influence):
+        if constraint.attrib.get('score', 'INFINITY') != score or (pcs_version in ['0.11', '0.12'] and 'influence=' + constraint.attrib.get('influence', 'true') != influence):
             result['changed'] = True
             if not module.check_mode:
                 rc, out, err = module.run_command(cmd_delete)

--- a/library/pcs_quorum_qdevice.py
+++ b/library/pcs_quorum_qdevice.py
@@ -114,8 +114,8 @@ def run_module():
     else:
         module.fail_json(msg="pcs --version exited with non-zero exit code (" + rc + "): " + out + err)
 
-    if pcs_version != '0.10':
-        module.fail_json(msg="unsupported version of pcs (" + pcs_version + "). Only version 0.10 is supported.")
+    if pcs_version not in ['0.10', '0.11', '0.12']:
+        module.fail_json(msg="unsupported version of pcs (" + pcs_version + "). Only versions 0.10, 0.11 and 0.12 are supported.")
 
     # EL 7 configuration file
     corosync_conf_exists = os.path.isfile('/etc/corosync/corosync.conf')


### PR DESCRIPTION
### Summary

Fixes version gates that incorrectly excluded pcs 0.12 (and 0.11 for qdevice)
from features the upstream tools support, despite the collection claiming
compatibility with pcs 0.9 through 0.12.

### Changes

#### 1. `pcs_constraint_colocation` — influence on pcs 0.12

The `influence` parameter gate used `pcs_version == '0.11'` (exact match),
which caused two problems on pcs 0.12:
- `influence=false` rejected with error "needs pcs version 0.11"
- `influence=true` silently ignored (fell through to empty-string default)

Fixed both locations (param handling and constraint comparison) to use
`pcs_version in ['0.11', '0.12']`.

#### 2. `pcs_quorum_qdevice` — rejected pcs 0.11 and 0.12

The version gate used `pcs_version != '0.10'`, immediately failing on
0.11 and 0.12. Changed to `pcs_version not in ['0.10', '0.11', '0.12']`.

#### 3. `pcs_auth` — stale error message

The deauth fallback error message listed "0.9 and 0.10" while the actual
elif branch already covers 0.9 through 0.12.

### Notes

- The `pcs_auth` deauth error message is technically unreachable with
  current code, but was fixed for correctness.